### PR TITLE
Allow direct access to mysql container by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ db:
   volumes:
     - ./mariadb:/var/lib/mysql
 #    - ./mariadb-init:/docker-entrypoint-initdb.d
+  ports:
+    - "3306:3306"
 app:
   image: wodby/drupal-php
   environment:


### PR DESCRIPTION
Useful for database management with MySQL Workbench, Navicat, etc.